### PR TITLE
Raw mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,10 @@ v3.0.2
 + Added tracker.php - a basic PHP script that will log POSTed data to a MySQL database and forward the data on to Geolink.
 + Added a "locate" SMS command that responds to the sender with a google maps link. By default this is in the comgooglemaps:// format which will open in the google maps iOS app, but it can be changed to normal https://maps.google links by setting LOCATE_COMMAND_FORMAT_IOS = 0 in tracker.h.
 + Added GSM_SEND_FAILURES_REBOOT options, if set to >0 this determines the number of consecutive GSM send failures that will trigger a reboot of the device.
+
+v3.0.3
+======
+
++ added SEND_RAW mode to send the data packet over a raw TCP connection in order to minimise bandwidth
++ added example daemon.rb ruby tcp server to accept and log the raw data packets
++ added boolean flags for all elements in the data packet so they can be turned on and off individually

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,15 @@ v3.0.3
 + added SEND_RAW mode to send the data packet over a raw TCP connection in order to minimise bandwidth
 + added example daemon.rb ruby tcp server to accept and log the raw data packets
 + added boolean flags for all elements in the data packet so they can be turned on and off individually
+
+Raw mode drastically reduces the bandwidth used by the OpenTracker.
+
+Example old data transmission using HTTP:
+
+POST /index.php HTTP/1.0\r\nHost: some.server.com \r\nContent-type: application/x-www-form-urlencoded\r\nContent-length: 42\r\nConnection: close\r\n\r\nimei=8634241016201447&key=xxxxxxxxx&d=15/05/10,09:40:40 0[100515,9404700,12.394991,-4.132110,0.02,18.70,346.90,67,15]12.24,0,2520#eof
+
+New data packet using raw mode and only a few select data items:
+
+xxxxxxxxx,12.345968,-1.234517,0.04,12.42,0,2880
+
+273 bytes down to 47 bytes

--- a/Opentracker_3_0_1/Opentracker_3_0_1.ino
+++ b/Opentracker_3_0_1/Opentracker_3_0_1.ino
@@ -192,7 +192,12 @@ void loop() {
      }
 
    //collecting GPS data
-   collect_all_data(IGNT_STAT);
+
+   if (SEND_RAW) {
+       collect_all_data_raw(IGNT_STAT);
+   } else {
+       collect_all_data(IGNT_STAT);
+   }
    debug_print(F("Current:")); 
    debug_print(data_current); 
    

--- a/Opentracker_3_0_1/data.ino
+++ b/Opentracker_3_0_1/data.ino
@@ -82,7 +82,86 @@
     
   }
   
-  
-  
-  
-  
+  void collect_all_data_raw(int ignitionState)
+  {
+    debug_print(F("collect_all_data_raw() started"));
+
+    gsm_get_time();
+
+    if (SEND_RAW_INCLUDE_KEY) {
+        for (int i=0;i<strlen(config.key);i++) {
+            data_current[data_index++] = config.key[i];
+        }
+    }
+
+    if (SEND_RAW_INCLUDE_TIMESTAMP) {
+        if (data_index >0) {
+            data_current[data_index++] = ',';
+        }
+        for(int i=0;i<strlen(time_char);i++) {
+            data_current[data_index++] = time_char[i];
+        }
+    }
+
+    collect_gps_data();
+
+    if (DATA_INCLUDE_BATTERY_LEVEL) {
+        if (data_index >0) {
+            data_current[data_index++] = ',';
+        }
+
+        // append battery level to data packet
+        float sensorValue = analogRead(AIN_S_INLEVEL);
+        float outputValue = sensorValue * (242.0f / 22.0f * ANALOG_VREF / 1024.0f);
+        char batteryLevel[20];
+        snprintf(batteryLevel,20,"%.2f",outputValue);
+
+        for (int i=0; i<strlen(batteryLevel); i++) {
+          data_current[data_index++] = batteryLevel[i];
+        }
+    }
+
+    // ignition state
+    if (DATA_INCLUDE_IGNITION_STATE) {
+        if (data_index >0) {
+            data_current[data_index++] = ',';
+        }
+        if (ignitionState == 0) {
+          data_current[data_index++] = '1';
+        } else {
+          data_current[data_index++] = '0';
+        }
+    }
+
+    // engine running time
+    if (DATA_INCLUDE_ENGINE_RUNNING_TIME) {
+        if (data_index >0) {
+            data_current[data_index++] = ',';
+        }
+
+        unsigned long currentRunningTime = engineRunningTime;
+        char runningTimeString[32];
+
+        if (engineRunning == 0) {
+          currentRunningTime += (millis() - engine_start);
+        }
+
+        snprintf(runningTimeString,32,"%ld",(unsigned long) currentRunningTime / 1000);
+
+        for (int i=0; i<strlen(runningTimeString); i++) {
+          data_current[data_index++] = runningTimeString[i];
+        }
+    }
+
+    if (!SEND_RAW) {
+        //end of data packet
+        data_current[data_index] = '\n';
+        data_index++;
+    }
+
+    //terminate data_current
+    data_current[data_index] = '\0';
+    data_index++;
+
+    debug_print(F("collect_all_data_raw() completed"));
+  }

--- a/Opentracker_3_0_1/gps.ino
+++ b/Opentracker_3_0_1/gps.ino
@@ -204,107 +204,102 @@
               gsm_set_time();             
             }
      
-            //converting date to data packet                    
-            ltoa(date_gps, tmp, 10);
-            for(int i=0;i<strlen(tmp);i++)
-              {
-               data_current[data_index] = tmp[i]; 
-               data_index++;
-              }
-              
-            data_current[data_index] = ',';  
-            data_index++;
-            
-            //time
-            ltoa(time_gps, tmp, 10);
-            for(int i=0;i<strlen(tmp);i++)
-              {
-               data_current[data_index] = tmp[i]; 
-               data_index++;
-              }
-      
-            data_current[data_index] = ',';  
-            data_index++;           
-             
-            //lat            
-            dtostrf(flat,1,6,tmp);                          
-            dtostrf(flat,1,6,lat_current);                          
-            for(int i=0;i<strlen(tmp);i++)
-              {
-               data_current[data_index] = tmp[i]; 
-               data_index++;
-              }
-    
-              
-            //lon 
-            data_current[data_index] = ',';  
-            data_index++;   
-           
-            dtostrf(flon,1,6,tmp);                          
-            dtostrf(flon,1,6,lon_current);                          
-            for(int i=0;i<strlen(tmp);i++)
-              {
-               data_current[data_index] = tmp[i]; 
-               data_index++;
-              }
- 
-            //kmph
-            data_current[data_index] = ',';  
-            data_index++;  
-            
-            dtostrf(fkmph,1,2,tmp);  
-            for(int i=0;i<strlen(tmp);i++)
-              {
-               data_current[data_index] = tmp[i]; 
-               data_index++;
-              }
-            
-            //alt
-            data_current[data_index] = ',';  
-            data_index++; 
+            int first_gps_item = 0;
 
-            dtostrf(falt,1,2,tmp);             
-            for(int i=0;i<strlen(tmp);i++)
-              {
-               data_current[data_index] = tmp[i]; 
-               data_index++;
-              }
-            
-            //fc (course)
-            data_current[data_index] = ',';  
-            data_index++; 
-            
-            dtostrf(fc,1,2,tmp);  
-            for(int i=0;i<strlen(tmp);i++)
-              {
-               data_current[data_index] = tmp[i]; 
-               data_index++;
-              }
+            if (DATA_INCLUDE_GPS_DATE) {
+                data_current[data_index++] = ',';
+
+                //converting date to data packet                    
+                ltoa(date_gps, tmp, 10);
+                for(int i=0;i<strlen(tmp);i++)
+                  {
+                   data_current[data_index] = tmp[i]; 
+                   data_index++;
+                  }
+            }
+
+            if (DATA_INCLUDE_GPS_TIME) {
+                data_current[data_index++] = ',';  
+
+                //time
+                ltoa(time_gps, tmp, 10);
+                for(int i=0;i<strlen(tmp);i++)
+                  {
+                   data_current[data_index] = tmp[i]; 
+                   data_index++;
+                  }
+            }
+             
+            if (DATA_INCLUDE_LATITUDE) {
+                data_current[data_index++] = ',';  
+
+                dtostrf(flat,1,6,tmp);                          
+                dtostrf(flat,1,6,lat_current);                          
+                for(int i=0;i<strlen(tmp);i++) {
+                    data_current[data_index++] = tmp[i]; 
+                }
+            }
+    
+            if (DATA_INCLUDE_LONGITUDE) {
+                data_current[data_index++] = ',';  
+
+                dtostrf(flon,1,6,tmp);                          
+                dtostrf(flon,1,6,lon_current);                          
+                for(int i=0;i<strlen(tmp);i++) {
+                    data_current[data_index++] = tmp[i]; 
+                }
+            }
+ 
+            if (DATA_INCLUDE_SPEED) {
+                data_current[data_index++] = ',';  
+
+                dtostrf(fkmph,1,2,tmp);  
+                for(int i=0;i<strlen(tmp);i++) {
+                    data_current[data_index++] = tmp[i]; 
+                }
+            }
+
+            if (DATA_INCLUDE_ALTITUDE) {
+                data_current[data_index++] = ',';  
+
+                dtostrf(falt,1,2,tmp);             
+                for(int i=0;i<strlen(tmp);i++) {
+                    data_current[data_index++] = tmp[i]; 
+                }
+            }
+
+            if (DATA_INCLUDE_HEADING) {
+                data_current[data_index++] = ',';  
+
+                dtostrf(fc,1,2,tmp);  
+                for(int i=0;i<strlen(tmp);i++) {
+                    data_current[data_index++] = tmp[i]; 
+                }
+            }
            
-           //hdop, satelites
-           long hdop = gps.hdop(); //hdop
-           long sats = gps.satellites(); //satellites          
-           
-           data_current[data_index] = ',';  
-           data_index++; 
-            
-           ltoa(hdop, tmp, 10);
-           for(int i=0;i<strlen(tmp);i++)
-              {
-               data_current[data_index] = tmp[i]; 
-               data_index++;
-              }
-              
-           data_current[data_index] = ',';  
-           data_index++;     
+
+           if (DATA_INCLUDE_HDOP) {
+               data_current[data_index++] = ',';  
+                
+               long hdop = gps.hdop(); //hdop
+
+               ltoa(hdop, tmp, 10);
+               for(int i=0;i<strlen(tmp);i++) {
+                    data_current[data_index++] = tmp[i]; 
+               }
+           }
+
+           if (DATA_INCLUDE_SATELLITES) {
+               data_current[data_index++] = ',';  
       
-           ltoa(sats, tmp, 10);
-           for(int i=0;i<strlen(tmp);i++)
-              {
-               data_current[data_index] = tmp[i]; 
-               data_index++;
-              }
-           
+               long sats = gps.satellites(); //satellites          
+
+               ltoa(sats, tmp, 10);
+               for(int i=0;i<strlen(tmp);i++) {
+                    data_current[data_index++] = tmp[i]; 
+               }
+           }
+
             //save last gps data date/time
             last_time_gps = time_gps;
             last_date_gps = date_gps;

--- a/Opentracker_3_0_1/parse.ino
+++ b/Opentracker_3_0_1/parse.ino
@@ -83,18 +83,22 @@
             
         }
       
-      tmp = strstr((cmd), "eof");  
-      if(tmp!=NULL) 
-          {                  
-            //all data was received by server
-            debug_print(F("Data was fully received by the server."));              
-            ret = 1;              
-          }
-          else
-          {
-            debug_print(F("Data was not received by the server."));              
-          }
-                
+      if (SEND_RAW) {
+          debug_print(F("RAW data mode enabled, not checking whether the packet was received or not."));
+          ret = 1;
+      } else {
+          tmp = strstr((cmd), "eof");  
+          if(tmp!=NULL) 
+              {                  
+                //all data was received by server
+                debug_print(F("Data was fully received by the server."));              
+                ret = 1;              
+              }
+              else
+              {
+                debug_print(F("Data was not received by the server."));              
+              }
+      }
         
      parse_cmd(cmd);        
      debug_print(F("parse_receive_reply() completed"));  

--- a/Opentracker_3_0_1/tracker.h.example
+++ b/Opentracker_3_0_1/tracker.h.example
@@ -18,6 +18,19 @@
 
   #define GSM_SEND_FAILURES_REBOOT 0  // 0 == disabled, increase to set the number of GSM failures that will trigger a reboot of the opentracker device
 
+  #define SEND_RAW 0 // enable to use the new raw tcp send method to minimise data use
+  #define SEND_RAW_INCLUDE_KEY 1
+  #define SEND_RAW_INCLUDE_TIMESTAMP 0
+
+  #define DATA_INCLUDE_GPS_DATE 1 // enable to include the GPS date in the POST string
+  #define DATA_INCLUDE_GPS_TIME 1 // enable to include the GPS time in the POST string
+  #define DATA_INCLUDE_LATITUDE 1 // enable to include latitude
+  #define DATA_INCLUDE_LONGITUDE 1 // enable to include longitude
+  #define DATA_INCLUDE_SPEED 1 // enable to include speed (km/h)
+  #define DATA_INCLUDE_ALTITUDE 1 // enable to include altitude
+  #define DATA_INCLUDE_HEADING 1 // enable to include heading
+  #define DATA_INCLUDE_HDOP 1 // enable to include hdop
+  #define DATA_INCLUDE_SATELLITES 1 // enable to include satellites
   #define DATA_INCLUDE_BATTERY_LEVEL 0  // enable to include the battery level in the POST string
   #define DATA_INCLUDE_IGNITION_STATE 0 // enable to include the ignition state in the POST string
   #define DATA_INCLUDE_ENGINE_RUNNING_TIME 0 // enable to include the engine running time (in seconds) in the POST string

--- a/daemon/daemon.rb
+++ b/daemon/daemon.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/ruby
+require 'socket'
+require 'mysql'
+require 'process'
+
+key = "password"
+server = "127.0.0.1"
+port = 80
+mysql_host = "127.0.0.1"
+mysql_user = "root"
+mysql_pass = ""
+mysql_db = "tracker"
+user = 65534
+group = 65534
+
+server = TCPServer.new(server, port)
+
+Process::Sys.setuid user
+Process::Sys.seteuid group
+
+while (session = server.accept)
+    Thread.start do
+        input = session.gets
+
+        m = input.match(/^([0-9a-zA-Z]+),([0-9\.\-]+),([0-9\.\-]+),([0-9\.]+),([0-9\.]+),([01]),([0-9]+)/);
+        if m[1] == key
+            con = Mysql.new mysql_host, mysql_user, mysql_pass, mysql_db
+
+            ts = Time.now.strftime("%Y-%m-%d %H:%M:%S");
+
+            con.query("INSERT into `log` (timestamp,lat,lon,speed,altitude,heading,vehicleBat,engineStatus,runningTime,ip) values ('#{ts}','#{m[2]}','#{m[3]}','#{m[4]}','0','0','#{m[5]}','#{m[6]}','#{m[7]}','#{session.peeraddr[2]}');");
+        end
+        session.close
+    end
+end


### PR DESCRIPTION
Hello again,
- added SEND_RAW mode to send the data packet over a raw TCP connection in order to minimise bandwidth
- added example daemon.rb ruby tcp server to accept and log the raw data packets
- added boolean flags for all elements in the data packet so they can be turned on and off individually

Raw mode drastically reduces the bandwidth used by the OpenTracker.

Example old data transmission using HTTP:

POST /index.php HTTP/1.0\r\nHost: some.server.com \r\nContent-type: application/x-www-form-urlencoded\r\nContent-length: 42\r\nConnection: close\r\n\r\nimei=8634241016201447&key=xxxxxxxxx&d=15/05/10,09:40:40 0[100515,9404700,12.394991,-4.132110,0.02,18.70,346.90,67,15]12.24,0,2520#eof

New data packet using raw mode and only a few select data items:

xxxxxxxxx,12.345968,-1.234517,0.04,12.42,0,2880

273 bytes down to 47 bytes.

For users sending 1440 requests/day like I do, that drops the monthly bandwidth from 11.25MB down to just 1.94MB.

Mark
