### PR TITLE
increased apn buffer to 64 bytes to allow for networks with long apn …

### DIFF
--- a/Opentracker_3_0_1/Opentracker_3_0_1.ino
+++ b/Opentracker_3_0_1/Opentracker_3_0_1.ino
@@ -48,7 +48,7 @@
   //settings structure  
   struct settings {
   
-    char apn[20];
+    char apn[64];
     char user[20];
     char pwd[20];
     long interval;          //how often to collect data (milli sec, 600000 - 10 mins)


### PR DESCRIPTION
increased apn buffer to 64 bytes to allow for networks with long apn hostnames.
